### PR TITLE
Join a match fix

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -38,7 +38,7 @@ app.use(cookieParser());
 app.use(express.static(join(__dirname, 'public')));
 
 
-app.use('/api/user', matchRouter);
+app.use('/api/match', matchRouter);
 app.use('/api', authRouter);
 
 // catch 404 and forward to error handler

--- a/server/controllers/match.js
+++ b/server/controllers/match.js
@@ -12,11 +12,11 @@ const addMatch = (req, res) => {
 
 // join a match by given matchID
 const joinMatch = (req, res) => {
-  const matchID = req.params;
+  const { matchID } = req.params;
   const id = req.userID;
   Match.findOneAndUpdate(
     {_id: matchID},
-    {$push: {'userIDs': {id}}},
+    {$push: {'userIDs': id}},
     {new: true}
   ).then(() => {
     res.status(200).json({status: 'Joining match'});

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -989,11 +989,6 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
-    "http": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/http/-/http-0.0.1-security.tgz",
-      "integrity": "sha512-RnDvP10Ty9FxqOtPZuxtebw1j4L/WiqNMDtuc1YMH1XQm5TgDRaR1G9u8upL6KD1bXHSp9eSXo/ED+8Q7FAr+g=="
-    },
     "http-cache-semantics": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
@@ -1062,9 +1057,9 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "ip-regex": {
       "version": "2.1.0",
@@ -1531,8 +1526,7 @@
     "mongoose-legacy-pluralize": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
-      "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ==",
-      "requires": {}
+      "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ=="
     },
     "morgan": {
       "version": "1.10.0",
@@ -2167,6 +2161,14 @@
         }
       }
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "strip-ansi": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -2486,9 +2488,9 @@
       "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q=="
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true
     },
     "yargs": {

--- a/server/package.json
+++ b/server/package.json
@@ -14,7 +14,6 @@
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "express-ws": "^4.0.0",
-    "http": "*",
     "http-errors": "~1.8.0",
     "jsonwebtoken": "^8.5.1",
     "mongoose": "^5.12.3",

--- a/server/routes/JoinMatch.js
+++ b/server/routes/JoinMatch.js
@@ -1,8 +1,0 @@
-const express = require('express');
-const match = require('../controllers/match');
-const verifyToken = require('../middlewares/authentication');
-const router = express.Router();
-
-router.post('/match/:matchID', verifyToken, match.joinMatch);
-
-module.exports = router;

--- a/server/routes/matchRouter.js
+++ b/server/routes/matchRouter.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const match = require('../controllers/match');
 const verifyToken = require('../middlewares/authentication');
 
-router.post('/newmatch', verifyToken, match.addMatch);
+router.post('/create', verifyToken, match.addMatch);
+router.post('/join/:matchID', verifyToken, match.joinMatch)
 
 module.exports = router;


### PR DESCRIPTION
The join a match controller was always returning 400 error, because we were passing an object called matchID to the search function. Changed it so that now we pass the value of matchID.

Missing route in app.js - added the route to the app

Also we were trying to add an object id to the array in update. Changed it so that we are passing the id value instead.

Tested with postman to make sure the controller returns 200 status upon receiving the correct matchID in the parameters 