### PR TITLE
added backend sockets for next move

### DIFF
--- a/server/socket.js
+++ b/server/socket.js
@@ -37,5 +37,20 @@ exports.socketConnect = function (server) {
             game[matchId].setInProgress();
             io.emit('update-game-engine-' + matchId, game[matchId].toJson());
         })
+
+        socket.on('next-turn', ({ matchId }) => {
+            game[matchId].nextTurn();
+            io.emit('update-game-engine-' + matchId, game[matchId].toJson());
+        })
+
+        socket.on('next-phase', ({ matchId }) => {
+            game[matchId].nextPhase();
+            io.emit('update-game-engine-' + matchId, game[matchId].toJson());
+        })
+
+        socket.on('check-card', ({ matchId }, row, column) => {
+            game[matchId].nextTurn(row, column);
+            io.emit('update-game-engine-' + matchId, game[matchId].toJson());
+        })
     });
 }

--- a/server/socket.js
+++ b/server/socket.js
@@ -49,7 +49,7 @@ exports.socketConnect = function (server) {
         })
 
         socket.on('check-card', ({ matchId }, row, column) => {
-            game[matchId].nextTurn(row, column);
+            game[matchId].checkCard(row, column);
             io.emit('update-game-engine-' + matchId, game[matchId].toJson());
         })
     });


### PR DESCRIPTION
Added backed socket listeners for next move.

-Listen for picking a card, takes a row and column and sends those to the game engine to determine what to do.
-Listens for next turn (might not need this and can combine with the picking a card but players can choose to pass)
-Listens for next phase